### PR TITLE
Refactor TaskList::findTasks to use streams

### DIFF
--- a/src/main/java/alice/storage/TaskList.java
+++ b/src/main/java/alice/storage/TaskList.java
@@ -101,13 +101,9 @@ public class TaskList {
      * @return         the tasks which contain the keyword
      */
     public List<Task> findTasks(String keyword) {
-        List<Task> results = new ArrayList<>();
-        for (Task task : tasks) {
-            if (task.containsKeyword(keyword)) {
-                results.add(task);
-            }
-        }
-        return results;
+        return tasks.stream()
+                .filter((task) -> task.containsKeyword(keyword))
+                .toList();
     }
 
     /**


### PR DESCRIPTION
Use streams instead of for loops to simplify the code.

Streams were already used in FindTask::execute and ListTask::execute.